### PR TITLE
由于在发包时，找不到模板，现将

### DIFF
--- a/src/components/Echarts/index.js
+++ b/src/components/Echarts/index.js
@@ -10,6 +10,9 @@ export default class App extends Component {
     }
   }
 
+  //由于在发包时，找不到模板，现将
+  //source={require('./tpl.html')}改为source={this.props.source}
+  //模板由外部传入
   render() {
     return (
       <View style={{flex: 1, height: this.props.height || 400,}}>
@@ -20,7 +23,7 @@ export default class App extends Component {
           style={{
             height: this.props.height || 400,
           }}
-          source={require('./tpl.html')}
+          source={this.props.source}
         />
       </View>
     );


### PR DESCRIPTION
 由于在发包时，找不到模板，现将source={require('./tpl.html')}改为source={this.props.source}，模板由外部传入，可在调用中使用source={require('./tpl.html')}