### PR TITLE
Add onPress

### DIFF
--- a/src/components/Echarts/index.js
+++ b/src/components/Echarts/index.js
@@ -21,6 +21,7 @@ export default class App extends Component {
             height: this.props.height || 400,
           }}
           source={require('./tpl.html')}
+          onMessage={event => this.props.onPress ? this.props.onPress(JSON.parse(event.nativeEvent.data)) : null}
         />
       </View>
     );

--- a/src/components/Echarts/renderChart.js
+++ b/src/components/Echarts/renderChart.js
@@ -7,5 +7,18 @@ export default function renderChart(props) {
     document.getElementById('main').style.height = "${height}px";
     var myChart = echarts.init(document.getElementById('main'));
     myChart.setOption(${toString(props.option)});
+    myChart.on('click', function(params) {
+      var seen = [];
+      var paramsString = JSON.stringify(params, function(key, val) {
+        if (val != null && typeof val == "object") {
+          if (seen.indexOf(val) >= 0) {
+            return;
+          }
+          seen.push(val);
+        }
+        return val;
+      });
+      window.postMessage(JSON.stringify(paramsString));
+    });
   `
 }

--- a/src/components/Echarts/renderChart.js
+++ b/src/components/Echarts/renderChart.js
@@ -18,7 +18,7 @@ export default function renderChart(props) {
         }
         return val;
       });
-      window.postMessage(JSON.stringify(paramsString));
+      window.postMessage(paramsString);
     });
   `
 }


### PR DESCRIPTION
Added onPress prop to listen for onClick events.

We are passing data over using window.postMessage. window.postMessage will serialise the data. However params has cyclic structures so it doesn't get serialised.

We have 2 options:

1. Do a manual serialise to filter out cyclic structures
2. Completely remove "event" property from params

I chose 1 to keep parmas consistent with echart but we can change it to 2 if you prefer.