### PR TITLE
处理ios11 高度只有设定height的一半

### DIFF
--- a/src/components/Echarts/index.js
+++ b/src/components/Echarts/index.js
@@ -20,6 +20,7 @@ export default class App extends Component {
           style={{
             height: this.props.height || 400,
           }}
+          scalesPageToFit={false}          
           source={require('./tpl.html')}
           onMessage={event => this.props.onPress ? this.props.onPress(JSON.parse(event.nativeEvent.data)) : null}
         />


### PR DESCRIPTION
ios11下，webview高度在更新后只有原有高度的一半