### PR TITLE
修复加载时白屏的问题

### DIFF
--- a/src/components/Echarts/index.js
+++ b/src/components/Echarts/index.js
@@ -21,6 +21,7 @@ export default class App extends Component {
             height: this.props.height || 400,
           }}
           source={require('./tpl.html')}
+          style={{backgroundColor: this.props.option.backgroundColor || 'rgba(0, 0, 0, 0)'}}
           onMessage={event => this.props.onPress ? this.props.onPress(JSON.parse(event.nativeEvent.data)) : null}
         />
       </View>


### PR DESCRIPTION
如果不传入 option.backgroundColor，背景为透明色
如果传入 option.backgroundColor，背景为传入的颜色
（option.backgroundColor 是 ECharts 的 背景色配置项）