### PR TITLE
Fix echarts displayed incorrect width in Android

### DIFF
--- a/src/components/Echarts/index.js
+++ b/src/components/Echarts/index.js
@@ -1,5 +1,5 @@
 import React, { Component } from 'react';
-import { WebView, View, StyleSheet } from 'react-native';
+import { WebView, View, StyleSheet, Platform } from 'react-native';
 import renderChart from './renderChart';
 import echarts from './echarts.min';
 
@@ -21,7 +21,7 @@ export default class App extends Component {
             height: this.props.height || 400,
             backgroundColor: this.props.backgroundColor || 'transparent'
           }}
-          scalesPageToFit={true}
+          scalesPageToFit={Platform.OS !== 'ios'}
           source={require('./tpl.html')}
           onMessage={event => this.props.onPress ? this.props.onPress(JSON.parse(event.nativeEvent.data)) : null}
         />

--- a/src/components/Echarts/index.js
+++ b/src/components/Echarts/index.js
@@ -21,7 +21,7 @@ export default class App extends Component {
             height: this.props.height || 400,
             backgroundColor: this.props.backgroundColor || 'transparent'
           }}
-          scalesPageToFit={false}          
+          scalesPageToFit={true}
           source={require('./tpl.html')}
           onMessage={event => this.props.onPress ? this.props.onPress(JSON.parse(event.nativeEvent.data)) : null}
         />

--- a/src/components/Echarts/tpl.html
+++ b/src/components/Echarts/tpl.html
@@ -4,6 +4,7 @@
     <link rel="shortcut icon" href="data:image/x-icon;," type="image/x-icon"> 
     <title>echarts</title>
     <meta http-equiv="content-type" content="text/html; charset=utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1">
     <style type="text/css">
       html,body {
         height: 100%;

--- a/src/components/Echarts/tpl.html
+++ b/src/components/Echarts/tpl.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html>
   <head>
+    <link rel="shortcut icon" href="data:image/x-icon;," type="image/x-icon"> 
     <title>echarts</title>
     <meta http-equiv="content-type" content="text/html; charset=utf-8">
     <style type="text/css">


### PR DESCRIPTION
## Reproduce

```
  const option = {
      ...
      xAxis: [
       {
          type: 'category',
          data: x,
          ...
        }
      ],
      yAxis: [
       {
          type: 'value',
          ...
        }
      ],
      series: [
        {
          type: 'line',
          data: y,
          ...
        }
      ]
    };

<Echarts option={option} height={200}/>
```

## Expected

To display the hole chart without scrolling.

![image](https://user-images.githubusercontent.com/5960988/34340546-f1ac532a-e9c0-11e7-98c3-cd801bfa4af9.png)

## Actual

chart displayed with scroll-x.

![dec-25-2017 22-11-12](https://user-images.githubusercontent.com/5960988/34340553-03b1d87e-e9c1-11e7-9827-674a1b048618.gif)


