### PR TITLE
添加一个主动刷新option的方法

### DIFF
--- a/src/components/Echarts/index.js
+++ b/src/components/Echarts/index.js
@@ -4,10 +4,21 @@ import renderChart from './renderChart';
 import echarts from './echarts.min';
 
 export default class App extends Component {
+
+  constructor(props) {
+    super(props);
+    this.setNewOption = this.setNewOption.bind(this);
+  }
+  
+
   componentWillReceiveProps(nextProps) {
     if(nextProps.option !== this.props.option) {
       this.refs.chart.reload();
     }
+  }
+
+  setNewOption(option) {
+    this.refs.chart.postMessage(JSON.stringify(option));
   }
 
   render() {

--- a/src/components/Echarts/renderChart.js
+++ b/src/components/Echarts/renderChart.js
@@ -9,6 +9,10 @@ export default function renderChart(props) {
     document.getElementById('main').style.width = "${width}";
     var myChart = echarts.init(document.getElementById('main'));
     myChart.setOption(${toString(props.option)});
+    window.document.addEventListener('message', function(e) {
+      var option = JSON.parse(e.data);
+      myChart.setOption(option);
+    });
     myChart.on('click', function(params) {
       var seen = [];
       var paramsString = JSON.stringify(params, function(key, val) {

--- a/src/index.js
+++ b/src/index.js
@@ -3,10 +3,15 @@ import { WebView, View } from 'react-native';
 import { Container, Echarts } from './components'
 
 export default class App extends Component {
+
+  setNewOption(option) {
+    this.chart.setNewOption(option);
+  }
+
   render() {
     return (
       <Container width={this.props.width}>
-        <Echarts {...this.props} />
+        <Echarts {...this.props} ref={e => this.chart = e}/>
       </Container>
     );
   }


### PR DESCRIPTION
当使用redux向echarts提供数据并且数据有更新的时候，echarts不会刷新成新的数据。
如果每次将redux提供的数据深拷贝，再传递数据，echarts会调用webView.reload()，导致界面闪动。
现在，对外提供一个setNewOption的方法，当有新数据需要传递给echarts时，webView会使用postMessage传递数据，在echarts网页中addEventListenser监听，再使用echarts的setOption，这样页面不仅不会闪动，还有echarts提供的动画。