### PR TITLE
扩展webview，允许传入的webview props

### DIFF
--- a/src/components/Echarts/index.js
+++ b/src/components/Echarts/index.js
@@ -1,5 +1,5 @@
 import React, { Component } from 'react';
-import { WebView, View, StyleSheet } from 'react-native';
+import { WebView, View, StyleSheet, Platform } from 'react-native';
 import renderChart from './renderChart';
 import echarts from './echarts.min';
 import PropTypes from "prop-types";
@@ -32,7 +32,7 @@ export default class App extends Component {
             backgroundColor: this.props.backgroundColor || 'transparent'
           }}
           scalesPageToFit={false}          
-          source={require('./tpl.html')}
+          source={(Platform.OS == 'ios') ? require('./tpl.html') : {uri:'file:///android_asset/tpl.html'}}
           onMessage={event => this.props.onPress ? this.props.onPress(JSON.parse(event.nativeEvent.data)) : null}
           {...this.props}
         />

--- a/src/components/Echarts/index.js
+++ b/src/components/Echarts/index.js
@@ -2,8 +2,18 @@ import React, { Component } from 'react';
 import { WebView, View, StyleSheet } from 'react-native';
 import renderChart from './renderChart';
 import echarts from './echarts.min';
+import PropTypes from "prop-types";
 
 export default class App extends Component {
+  static propTypes = {
+    ...WebView.propTypes,
+    option: PropTypes.object.isRequired,
+    width: PropTypes.number,
+    height: PropTypes.number,
+    backgroundColor: PropTypes.string,
+    onPress: PropTypes.func,
+  }
+
   componentWillReceiveProps(nextProps) {
     if(nextProps.option !== this.props.option) {
       this.refs.chart.reload();
@@ -24,6 +34,7 @@ export default class App extends Component {
           scalesPageToFit={false}          
           source={require('./tpl.html')}
           onMessage={event => this.props.onPress ? this.props.onPress(JSON.parse(event.nativeEvent.data)) : null}
+          {...this.props}
         />
       </View>
     );


### PR DESCRIPTION
1. 添加proptypes
2. 扩展webview props（提升自由度，安卓端页面滑动的问题也可以通过设置相关属性解决）